### PR TITLE
Umbra deletes: Move schema definitions to DDL file

### DIFF
--- a/umbra/ddl/schema-delete-candidates.sql
+++ b/umbra/ddl/schema-delete-candidates.sql
@@ -16,8 +16,14 @@ CREATE TABLE Person_likes_Post_Delete_candidates     (deletionDate timestamp wit
 CREATE TABLE Forum_hasMember_Person_Delete_candidates(deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null) WITH (storage = paged);
 CREATE TABLE Person_knows_Person_Delete_candidates   (deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null) WITH (storage = paged);
 
+-- If DELETE USING matches multiple times on a single row (in the table-under-deletion),
+-- Umbra throws an error: 'more than one row returned by a subquery used as an expression'
+-- To prevent this, we use '..._unique' tables which do not contain timestamps (which are
+-- not required for performing the delete) and are filtered to distinct id values.
 DROP TABLE IF EXISTS Comment_Delete_candidates_unique;
 DROP TABLE IF EXISTS Post_Delete_candidates_unique;
+DROP TABLE IF EXISTS Forum_Delete_candidates_unique;
 
 CREATE TABLE Comment_Delete_candidates_unique(id bigint not null) WITH (storage = paged);
 CREATE TABLE Post_Delete_candidates_unique(id bigint not null) WITH (storage = paged);
+CREATE TABLE Forum_Delete_candidates_unique(deletionDate timestamp with time zone not null, id bigint not null) WITH (storage = paged);

--- a/umbra/ddl/schema-delete-candidates.sql
+++ b/umbra/ddl/schema-delete-candidates.sql
@@ -15,3 +15,9 @@ CREATE TABLE Person_likes_Comment_Delete_candidates  (deletionDate timestamp wit
 CREATE TABLE Person_likes_Post_Delete_candidates     (deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null) WITH (storage = paged);
 CREATE TABLE Forum_hasMember_Person_Delete_candidates(deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null) WITH (storage = paged);
 CREATE TABLE Person_knows_Person_Delete_candidates   (deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null) WITH (storage = paged);
+
+DROP TABLE IF EXISTS Comment_Delete_candidates_unique;
+DROP TABLE IF EXISTS Post_Delete_candidates_unique;
+
+CREATE TABLE Comment_Delete_candidates_unique(id bigint not null) WITH (storage = paged);
+CREATE TABLE Post_Delete_candidates_unique(id bigint not null) WITH (storage = paged);

--- a/umbra/dml/snb-deletes.sql
+++ b/umbra/dml/snb-deletes.sql
@@ -1,3 +1,6 @@
+DELETE FROM Comment_Delete_candidates_unique;
+DELETE FROM Post_Delete_candidates_unique;
+
 ----------------------------------------------------------------------------------------------------
 -- DEL1: Remove Person, its personal Forums, and its Message (sub)threads --------------------------
 ----------------------------------------------------------------------------------------------------
@@ -121,8 +124,6 @@ WHERE Forum_hasMember_Person_Delete_candidates.src = Forum_hasMember_Person.Foru
 ----------------------------------------------------------------------------------------------------
 -- DEL6: Remove Post thread ------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
-DROP TABLE IF EXISTS Post_Delete_candidates_unique;
-CREATE TABLE Post_Delete_candidates_unique(id bigint not null);
 INSERT INTO Post_Delete_candidates_unique
   SELECT DISTINCT id
   FROM Post_Delete_candidates;
@@ -153,8 +154,6 @@ JOIN Post_Delete_candidates
 ----------------------------------------------------------------------------------------------------
 -- DEL7: Remove Comment subthread ------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
-DROP TABLE IF EXISTS Comment_Delete_candidates_unique;
-CREATE TABLE Comment_Delete_candidates_unique(id bigint not null);
 INSERT INTO Comment_Delete_candidates_unique
   SELECT DISTINCT id
   FROM Comment_Delete_candidates;


### PR DESCRIPTION
When doing a test with 5+ batches on SF100 with Umbra, the deletes failed.

```sql
DELETE FROM Forum 
USING Forum_Delete_candidates 
WHERE Forum.id = Forum_Delete_candidates.id 
```
```console
Traceback (most recent call last):
  File "/data/ldbc_snb_bi/umbra/benchmark.py", line 264, in <module>
    run_batch_updates(pg_con, data_dir, batch_start_date, timings_file)
  File "/data/ldbc_snb_bi/umbra/benchmark.py", line 210, in run_batch_updates
    run_script(pg_con, cur, "dml/snb-deletes.sql")
  File "/data/ldbc_snb_bi/umbra/benchmark.py", line 117, in run_script
    cur.execute(query)
psycopg2.errors.CardinalityViolation: more than one row returned by a subquery used as an expression
```

This PR fixes this.