### PR TITLE
Fix values for non-matching tuples in Umbra Q2

### DIFF
--- a/umbra/queries/bi-2.sql
+++ b/umbra/queries/bi-2.sql
@@ -24,10 +24,10 @@ SELECT t.id as TagId
  GROUP BY t.id
 )
 SELECT t.name AS "tag.name"
-     , countMonth1
-     , countMonth2
-     , abs(countMonth1-countMonth2) AS diff
+     , coalesce(countMonth1, 0)
+     , coalesce(countMonth2, 0)
+     , abs(coalesce(countMonth1, 0)-coalesce(countMonth2, 0)) AS diff
   FROM MyTag t LEFT JOIN detail ON t.id = detail.TagId
- ORDER BY diff desc nulls last, t.name
+ ORDER BY diff desc, t.name
  LIMIT 100
 ;


### PR DESCRIPTION
Umbra should have been outputting 0s instead of nulls for non-matching tuples.

(Sorry for the back-and forth on this)