### PR TITLE
Paramgen: Filter paths for Q15a

### DIFF
--- a/paramgen/paramgen-queries/pg-15a.sql
+++ b/paramgen/paramgen-queries/pg-15a.sql
@@ -1,13 +1,29 @@
 SELECT DISTINCT
-    people4Hops.person1Id AS 'person1Id:ID',
-    people4Hops.person2Id AS 'person2Id:ID',
-    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS startAnchorDate FROM creationDayNumMessages) - INTERVAL (people4Hops.person1Id % 7) DAY AS 'startDate:DATE',
-    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS endAnchorDate   FROM creationDayNumMessages) + INTERVAL (people4Hops.person2Id % 7) DAY AS 'endDate:DATE'
-FROM people4Hops
--- only keep person pairs where both persons exist in the benchmark's time window
-JOIN personDays_window p1
-  ON p1.id = people4Hops.person1Id
-JOIN personDays_window p2
-  ON p2.id = people4Hops.person2Id
-ORDER BY md5(131*people4Hops.person1Id + 241*people4Hops.person2Id), md5(people4Hops.person1Id)
+    people4Hops_sample.person1Id AS 'person1Id:ID',
+    people4Hops_sample.person2Id AS 'person2Id:ID',
+    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS startAnchorDate FROM creationDayNumMessages) - INTERVAL (people4Hops_sample.person1Id % 7) DAY AS 'startDate:DATE',
+    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS endAnchorDate   FROM creationDayNumMessages) + INTERVAL (people4Hops_sample.person2Id % 7) DAY AS 'endDate:DATE'
+
+FROM (
+  SELECT *
+  FROM people4Hops
+  LIMIT 500
+) people4Hops_sample
+
+-- two hops from person1Id
+JOIN personKnowsPersonDays_window knows1
+  ON knows1.person1Id = people4Hops_sample.person1Id
+JOIN personKnowsPersonDays_window knows2
+  ON knows2.person1Id = knows1.person2Id
+
+-- two hops from person2Id
+JOIN personKnowsPersonDays_window knows4
+  ON knows4.person1Id = people4Hops_sample.person2Id
+JOIN personKnowsPersonDays_window knows3
+  ON knows3.person1Id = knows4.person2Id
+
+-- meet in the middle
+WHERE knows2.person2Id = knows3.person2Id
+
+ORDER BY md5(131*people4Hops_sample.person1Id + 241*people4Hops_sample.person2Id), md5(people4Hops_sample.person1Id)
 LIMIT 400

--- a/paramgen/paramgen-queries/pg-15a.sql
+++ b/paramgen/paramgen-queries/pg-15a.sql
@@ -1,29 +1,35 @@
 SELECT DISTINCT
-    people4Hops_sample.person1Id AS 'person1Id:ID',
-    people4Hops_sample.person2Id AS 'person2Id:ID',
-    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS startAnchorDate FROM creationDayNumMessages) - INTERVAL (people4Hops_sample.person1Id % 7) DAY AS 'startDate:DATE',
-    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS endAnchorDate   FROM creationDayNumMessages) + INTERVAL (people4Hops_sample.person2Id % 7) DAY AS 'endDate:DATE'
+    p1Id AS 'person1Id:ID',
+    p2Id AS 'person2Id:ID',
+    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS startAnchorDate FROM creationDayNumMessages) - INTERVAL (p1Id % 7) DAY AS 'startDate:DATE',
+    (SELECT date_trunc('day', percentile_disc(0.95) WITHIN GROUP (ORDER BY creationDay)) AS endAnchorDate   FROM creationDayNumMessages) + INTERVAL (p2Id % 7) DAY AS 'endDate:DATE'
 
-FROM (
-  SELECT *
-  FROM people4Hops
-  LIMIT 500
-) people4Hops_sample
-
--- two hops from person1Id
-JOIN personKnowsPersonDays_window knows1
-  ON knows1.person1Id = people4Hops_sample.person1Id
-JOIN personKnowsPersonDays_window knows2
-  ON knows2.person1Id = knows1.person2Id
+FROM
+  (
+    SELECT DISTINCT
+      people4Hops_sample.person1Id AS p1Id,
+      people4Hops_sample.person2Id AS p2Id,
+      knows2.person2Id AS middleCandidate
+    FROM (
+      SELECT *
+      FROM people4Hops
+      LIMIT 500
+    ) people4Hops_sample
+    -- two hops from person1Id
+    JOIN personKnowsPersonDays_window knows1
+      ON knows1.person1Id = people4Hops_sample.person1Id
+    JOIN personKnowsPersonDays_window knows2
+      ON knows2.person1Id = knows1.person2Id
+  ) sub
 
 -- two hops from person2Id
 JOIN personKnowsPersonDays_window knows4
-  ON knows4.person1Id = people4Hops_sample.person2Id
+  ON knows4.person1Id = p2Id
 JOIN personKnowsPersonDays_window knows3
   ON knows3.person1Id = knows4.person2Id
 
 -- meet in the middle
-WHERE knows2.person2Id = knows3.person2Id
+WHERE middleCandidate = knows3.person2Id
 
-ORDER BY md5(131*people4Hops_sample.person1Id + 241*people4Hops_sample.person2Id), md5(people4Hops_sample.person1Id)
+ORDER BY md5(131*p1Id + 241*p2Id), md5(p1Id)
 LIMIT 400

--- a/paramgen/paramgen-queries/pg-15a.sql
+++ b/paramgen/paramgen-queries/pg-15a.sql
@@ -13,7 +13,7 @@ FROM
     FROM (
       SELECT *
       FROM people4Hops
-      LIMIT 500
+      LIMIT 80
     ) people4Hops_sample
     -- two hops from person1Id
     JOIN personKnowsPersonDays_window knows1
@@ -32,4 +32,3 @@ JOIN personKnowsPersonDays_window knows3
 WHERE middleCandidate = knows3.person2Id
 
 ORDER BY md5(131*p1Id + 241*p2Id), md5(p1Id)
-LIMIT 400

--- a/paramgen/paramgen.py
+++ b/paramgen/paramgen.py
@@ -30,6 +30,13 @@ for entity in ["personDays", "personKnowsPersonDays", "personStudyAtUniversityDa
               AND deletionDay > TIMESTAMP '2013-01-01'
         """)
 
+# insert knows edges backwards
+con.execute(f"""
+    INSERT INTO personKnowsPersonDays_window
+        SELECT Person2Id, Person1Id
+        FROM personKnowsPersonDays_window
+    """)
+
 print()
 print("============ Creating materialized views ============")
 # d: drop


### PR DESCRIPTION
Will fix #103

On an `r6id.2xlarge`, unoptimized version:

* SF100: 8GB RAM, 63s
* SF300: 21GB RAM, 130s
* SF1000: ran out of memory after 171s

Optimized (factorized) version:

* SF100: 5GB RAM, 45s
* SF300: 12GB, 112s
* SF1000: 45GB, 292s