### PR TITLE
umbra: optimize queries

### DIFF
--- a/umbra/queries/bi-17.sql
+++ b/umbra/queries/bi-17.sql
@@ -15,7 +15,7 @@ FROM MyMessage Message1
 JOIN MyMessage Message2
  ON (Message1.creationDate + ':delta hour'::interval) < Message2.creationDate
 JOIN MyMessage Comment
- ON coalesce(Comment.ParentPostId, Comment.ParentCommentId) = Message2.MessageId
+ ON Comment.ParentMessageId = Message2.MessageId
 -- (forum1)-[:Has_MEMBER]->(person2)
 JOIN Forum_hasMember_Person Forum_hasMember_Person2
   ON Forum_hasMember_Person2.ForumId = Message1.ContainerForumId -- forum1

--- a/umbra/queries/bi-2.sql
+++ b/umbra/queries/bi-2.sql
@@ -12,8 +12,8 @@ SELECT Tag.id AS id, Tag.name AS name
 ),
 detail AS (
 SELECT t.id as TagId
-     , count(DISTINCT CASE WHEN Message.creationDate <  :date + INTERVAL '100 days' THEN Message.MessageId ELSE NULL END) AS countMonth1
-     , count(DISTINCT CASE WHEN Message.creationDate >= :date + INTERVAL '100 days' THEN Message.MessageId ELSE NULL END) AS countMonth2
+     , count(CASE WHEN Message.creationDate <  :date + INTERVAL '100 days' THEN Message.MessageId ELSE NULL END) AS countMonth1
+     , count(CASE WHEN Message.creationDate >= :date + INTERVAL '100 days' THEN Message.MessageId ELSE NULL END) AS countMonth2
   FROM MyTag t
   JOIN Message_hasTag_Tag
          ON Message_hasTag_tag.TagId = t.id

--- a/umbra/queries/bi-3.sql
+++ b/umbra/queries/bi-3.sql
@@ -6,25 +6,26 @@ SELECT Forum.id                AS "forum.id"
      , Forum.title             AS "forum.title"
      , Forum.creationDate      AS "forum.creationDate"
      , Forum.ModeratorPersonId AS "person.id"
-     , count(DISTINCT Message.MessageId) AS messageCount
-  FROM TagClass
-  JOIN Tag
-    ON Tag.TypeTagClassId = TagClass.id
-  JOIN Message_hasTag_Tag
-    ON Message_hasTag_Tag.TagId = Tag.id
-  JOIN Message
-    ON Message.MessageId = Message_hasTag_Tag.MessageId
-  JOIN Forum
-    ON Forum.id = Message.ContainerForumId
-  JOIN Person AS ModeratorPerson
-    ON ModeratorPerson.id = Forum.ModeratorPersonId
-  JOIN City
-    ON City.id = ModeratorPerson.LocationCityId
-  JOIN Country
-    ON Country.id = City.PartOfCountryId
-   AND Country.name = :country
- WHERE TagClass.name = :tagClass
- GROUP BY Forum.id, Forum.title, Forum.creationDate, Forum.ModeratorPersonId
- ORDER BY messageCount DESC, Forum.id
- LIMIT 20
+     , count(Message.MessageId) AS messageCount
+FROM Message
+JOIN Forum
+  ON Forum.id = Message.ContainerForumId
+JOIN Person AS ModeratorPerson
+  ON ModeratorPerson.id = Forum.ModeratorPersonId
+JOIN City
+  ON City.id = ModeratorPerson.LocationCityId
+JOIN Country
+  ON Country.id = City.PartOfCountryId
+ AND Country.name = :country
+WHERE EXISTS (
+  SELECT 1
+    FROM TagClass
+    JOIN Tag
+      ON Tag.TypeTagClassId = TagClass.id
+    JOIN Message_hasTag_Tag
+      ON Message_hasTag_Tag.TagId = Tag.id
+   WHERE Message.MessageId = Message_hasTag_Tag.MessageId AND TagClass.name = :tagClass)
+GROUP BY Forum.id, Forum.title, Forum.creationDate, Forum.ModeratorPersonId
+ORDER BY messageCount DESC, Forum.id
+LIMIT 20
 ;

--- a/umbra/scripts/vars.sh
+++ b/umbra/scripts/vars.sh
@@ -8,7 +8,7 @@ export UMBRA_DATABASE_DIR=`pwd`/scratch/db/
 export UMBRA_LOG_DIR=`pwd`/scratch/log/
 export UMBRA_DDL_DIR=`pwd`/ddl/
 export UMBRA_CONTAINER_NAME=snb-bi-umbra
-export UMBRA_VERSION=788ebccb5
+export UMBRA_VERSION=11f9452d8
 export UMBRA_DOCKER_IMAGE=umbra-release:${UMBRA_VERSION}
 
 cd scripts


### PR DESCRIPTION
Q2: as TagId, MessageId is key of the subquery detail, we do not need `count(distinct ...)`

Q3: prefer semi-joins over `count(distinct ...)`