### PR TITLE
Correct reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ cd ..
 scripts/cross-validate.sh cypher umbra
 ```
 
-Note that the cross-validation uses the [numdiff](scripts/numdiff.md) CLI tool.
-
 ## Usage
 
 See [`.circleci/config.yml`](.circleci/config.yml) for an up-to-date example on how to use the projects in this repository.


### PR DESCRIPTION
The top-level `README.md` mentions a dependency on the `numdiff` tool which no longer exists. The current cross-validation in `scripts/cross-validate.py` does its own line counting and diffing with the Python `recursive_diff` module.
