### PR TITLE
TigerGraph: Switch default version from 3.7.0 to 3.9.3-2

### DIFF
--- a/tigergraph/ddl/ExprFunctions.hpp
+++ b/tigergraph/ddl/ExprFunctions.hpp
@@ -57,12 +57,6 @@ namespace UDIMPL {
   inline int64_t float_to_int (float val) {
     return (int64_t) val;
   }
-
-  inline string to_string (double val) {
-    char result[200];
-    sprintf(result, "%g", val);
-    return string(result);
-  }
   
   inline string bigint_to_string (int64_t val) {
     char result[200];

--- a/tigergraph/ddl/setup.sh
+++ b/tigergraph/ddl/setup.sh
@@ -13,7 +13,29 @@ echo "QUERY_PATH: ${QUERY_PATH}"
 echo "QUERY_PATH: ${DML_PATH}"
 echo "==============================================================================="
 t0=$SECONDS
+
+function enable_put_expr() {
+    echo "Enable put ExprFunctions feature"
+    if [[ -z "$(gadmin config list entry | grep "GSQL.UDF.Policy.Enable")" ]];then
+        echo "Config GSQL.UDF.EnablePutExpr does not exist, skip."
+    else
+        gadmin config set GSQL.UDF.Policy.Enable false
+    fi
+
+    if [[ -z "$(gadmin config list entry | grep "GSQL.UDF.EnablePutExpr")" ]]; then
+        echo "Config GSQL.UDF.EnablePutExpr does not exist, skip."
+    else
+        gadmin config set GSQL.UDF.EnablePutExpr true
+        gadmin config set GSQL.UDF.EnablePutTokenBank true
+        gadmin config set GSQL.UDF.EnablePutTgExpr true
+        gadmin config apply -y
+        gadmin restart -y
+        sleep 30
+    fi
+}
+
 #gsql drop all
+enable_put_expr
 gsql PUT TokenBank FROM \"$DDL_PATH/TokenBank.cpp\"
 gsql PUT ExprFunctions FROM \"$DDL_PATH/ExprFunctions.hpp\"
 gsql $DDL_PATH/schema.gsql

--- a/tigergraph/ddl/setup.sh
+++ b/tigergraph/ddl/setup.sh
@@ -12,7 +12,6 @@ echo "DATA_PATH: ${DATA_PATH}"
 echo "QUERY_PATH: ${QUERY_PATH}"
 echo "QUERY_PATH: ${DML_PATH}"
 echo "==============================================================================="
-t0=$SECONDS
 
 function enable_put_expr() {
     echo "Enable put ExprFunctions feature"
@@ -33,9 +32,10 @@ function enable_put_expr() {
         sleep 30
     fi
 }
-
-#gsql drop all
 enable_put_expr
+
+t0=$SECONDS
+#gsql drop all
 gsql PUT TokenBank FROM \"$DDL_PATH/TokenBank.cpp\"
 gsql PUT ExprFunctions FROM \"$DDL_PATH/ExprFunctions.hpp\"
 gsql $DDL_PATH/schema.gsql

--- a/tigergraph/k8s/README.md
+++ b/tigergraph/k8s/README.md
@@ -83,7 +83,7 @@ export VERSION=0.0.4
 export DOCKER_REGISTRY=docker.io
 export DOCKER_IMAGE_REPO=tginternal
 export HELM_REPO=http://docker.tigergraph.com
-export TG_CLUSTER_VERSION_DEFAULT=3.7.0
+export TG_CLUSTER_VERSION_DEFAULT=3.9.3-2
 kubectl tg init --helm-repo ${HELM_REPO} --docker-registry ${DOCKER_REGISTRY} --docker-image-repo ${DOCKER_IMAGE_REPO} --image-pull-policy Always --operator-version ${VERSION}
 ```
 
@@ -205,7 +205,7 @@ Deploy the containers using the script `k8s/tg` from [tigergraph/ecosys](https:/
 ```
 git clone https://github.com/tigergraph/ecosys.git
 cd ecosys/k8s
-./tg gke kustomize -v 3.7.0 -n tigergraph -s 4 --pv 700 --cpu 30 --mem 200 -l [license string]
+./tg gke kustomize -v 3.9.3-2 -n tigergraph -s 4 --pv 700 --cpu 30 --mem 200 -l [license string]
 kubectl apply -f ./deploy/tigergraph-eks-tigergraph.yaml
 ```
 ## Verify deployment

--- a/tigergraph/scripts/vars.sh
+++ b/tigergraph/scripts/vars.sh
@@ -3,7 +3,7 @@ pushd . > /dev/null
 cd "$( cd "$( dirname "${BASH_SOURCE[0]:-${(%):-%x}}" )" >/dev/null 2>&1 && pwd )"
 cd ..
 
-export TG_VERSION=3.7.0
+export TG_VERSION=3.9.3-2
 export TG_CONTAINER_NAME=snb-bi-tg
 export TG_DDL_DIR=`pwd`/ddl
 export TG_QUERIES_DIR=`pwd`/queries


### PR DESCRIPTION
1. Switch version from 3.7.0 to 3.9.3-2. (3.7.0 has been removed)
2. Delete user-define function `to_string`. (3.9.3 already has this built-in function)
3. Add some necessary configurations of 3.9.3-2.