### PR TITLE
Allow using more recent DuckDB versions for paramgen

### DIFF
--- a/paramgen/paramgen-queries/pg-1.sql
+++ b/paramgen/paramgen-queries/pg-1.sql
@@ -14,4 +14,4 @@ FROM (
     ORDER BY diff, creationDay
     LIMIT 80
 )
-ORDER BY md5(creationDay)
+ORDER BY md5(creationDay::VARCHAR)

--- a/paramgen/paramgen-queries/pg-12.sql
+++ b/paramgen/paramgen-queries/pg-12.sql
@@ -36,9 +36,9 @@ FROM (SELECT
                 ORDER BY salt, md5(concat(lang.language, salt))
             ),
             (SELECT unnest(generate_series(1, 4)) AS lang_perm)
-        ORDER BY startDate, salt, md5(3532569367*salt + 342663089*lang_perm)
+        ORDER BY startDate, salt, md5((3532569367*salt + 342663089*lang_perm)::VARCHAR)
     )
 )
 WHERE rn <= 3
 GROUP BY startDate, salt, lang_perm
-ORDER BY md5(startDate), lang_perm
+ORDER BY md5(startDate::VARCHAR), lang_perm

--- a/paramgen/paramgen-queries/pg-15a.sql
+++ b/paramgen/paramgen-queries/pg-15a.sql
@@ -14,4 +14,4 @@ JOIN personKnowsPersonDays_window knows3
 -- meet in the middle
 WHERE middleCandidate = knows3.person2Id
 
-ORDER BY md5(131*q15a_core.person1Id + 241*q15a_core.person2Id), md5(q15a_core.person1Id)
+ORDER BY md5((131*q15a_core.person1Id + 241*q15a_core.person2Id)::VARCHAR), md5(q15a_core.person1Id::VARCHAR)

--- a/paramgen/paramgen-queries/pg-15b.sql
+++ b/paramgen/paramgen-queries/pg-15b.sql
@@ -10,5 +10,5 @@ JOIN personKnowsPersonDays_window knows1
 JOIN personKnowsPersonDays_window knows2
   ON knows2.person1Id = knows1.person2Id
  AND knows2.person2Id = people2Hops.person2Id
-ORDER BY md5(131*people2Hops.person1Id + 241*people2Hops.person2Id), md5(people2Hops.person1Id)
+ORDER BY md5((131*people2Hops.person1Id + 241*people2Hops.person2Id)::VARCHAR), md5(people2Hops.person1Id::VARCHAR)
 LIMIT 400

--- a/paramgen/paramgen-queries/pg-19a.sql
+++ b/paramgen/paramgen-queries/pg-19a.sql
@@ -10,5 +10,5 @@ FROM
     FROM cityPairsNumFriends
     WHERE country1Id <> country2Id
     ORDER BY diff, city1Id, city2Id)
-ORDER BY md5(3532569367::bigint*city1Id + 342663089::bigint*city2Id)
+ORDER BY md5((3532569367::bigint*city1Id + 342663089::bigint*city2Id)::VARCHAR)
 LIMIT 400

--- a/paramgen/paramgen-queries/pg-19b.sql
+++ b/paramgen/paramgen-queries/pg-19b.sql
@@ -10,5 +10,5 @@ FROM
     FROM cityPairsNumFriends
     WHERE country1Id = country2Id
     ORDER BY diff, city1Id, city2Id)
-ORDER BY md5(3532569367::bigint*city1Id + 342663089::bigint*city2Id)
+ORDER BY md5((3532569367::bigint*city1Id + 342663089::bigint*city2Id)::VARCHAR)
 LIMIT 400

--- a/paramgen/paramgen-queries/pg-20a.sql
+++ b/paramgen/paramgen-queries/pg-20a.sql
@@ -22,7 +22,7 @@ FROM
     FROM personNumFriends
     JOIN personDays_window
       ON personDays_window.id = personNumFriends.id
-    ORDER BY diff, md5(personNumFriends.id)
+    ORDER BY diff, md5(personNumFriends.id::VARCHAR)
     LIMIT 50
     ) s2
 JOIN sameUniversityConnected c1
@@ -36,5 +36,5 @@ WHERE NOT EXISTS (
       AND w.PersonId = c2.personId
       AND c1.Component = c2.Component
     )
-ORDER BY md5(concat(s2.personId, s1.companyId)), md5(s2.personId), md5(s1.companyId)
+ORDER BY md5(concat(s2.personId, s1.companyId)), md5(s2.personId::VARCHAR), md5(s1.companyId::VARCHAR)
 LIMIT 400

--- a/paramgen/paramgen-queries/pg-20b.sql
+++ b/paramgen/paramgen-queries/pg-20b.sql
@@ -9,5 +9,5 @@ WHERE NOT EXISTS (SELECT 1
         WHERE work.companyId = q20b_twohop.companyId
           AND work.personId = q20b_twohop.person2Id
         )
-ORDER BY md5(q20b_twohop.person2Id), md5(q20b_twohop.companyId)
+ORDER BY md5(q20b_twohop.person2Id::VARCHAR), md5(q20b_twohop.companyId::VARCHAR)
 LIMIT 400

--- a/paramgen/paramgen-queries/pg-20b_comp.sql
+++ b/paramgen/paramgen-queries/pg-20b_comp.sql
@@ -9,11 +9,11 @@ FROM (
         name AS companyName,
         frequency AS freq,
         abs(frequency - (SELECT percentile_disc(0.47) WITHIN GROUP (ORDER BY frequency) FROM companyNumEmployees)) AS diff,
-        row_number() OVER (PARTITION BY personWorkAtCompanyDays_window.companyId ORDER BY md5(personWorkAtCompanyDays_window.personId)) AS rnum
+        row_number() OVER (PARTITION BY personWorkAtCompanyDays_window.companyId ORDER BY md5(personWorkAtCompanyDays_window.personId::VARCHAR)) AS rnum
     FROM companyNumEmployees
     JOIN personWorkAtCompanyDays_window
     ON personWorkAtCompanyDays_window.companyId = companyNumEmployees.id
-    ORDER BY diff, md5(personWorkAtCompanyDays_window.personId), md5(personWorkAtCompanyDays_window.companyId)
+    ORDER BY diff, md5(personWorkAtCompanyDays_window.personId::VARCHAR), md5(personWorkAtCompanyDays_window.companyId::VARCHAR)
 )
 WHERE rnum < 5
 LIMIT 200

--- a/paramgen/paramgen-queries/pg-4.sql
+++ b/paramgen/paramgen-queries/pg-4.sql
@@ -5,4 +5,4 @@ FROM (
     ORDER BY creationDay ASC
     LIMIT 40
 )
-ORDER BY md5(creationDay)
+ORDER BY md5(creationDay::VARCHAR)

--- a/paramgen/scripts/install-dependencies.sh
+++ b/paramgen/scripts/install-dependencies.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-pip3 install --user duckdb==0.9.2 pytz
+pip3 install --user duckdb pytz


### PR DESCRIPTION
While most of the queries used are already compatible with DuckDB 1.0, a few rely on `md5` working for non-`VARCHAR` types, which seems to not be the case anymore. Adding explicit casts fixes the issue.